### PR TITLE
Machine-readable data section in dataset page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It includes display control on the CKAN to ensure UKDS Theme is applied and bloc
 3. Front page background handling
 4. Blockage of Activity Stream access for normal site visitor
 5. Fix for template issue on CKAN [No. 6931](https://github.com/ckan/ckan/issues/6931)
+6. "Machine-readable data" section in the dataset page. Only visible when DCAT extension is installed.
 
 
 ## Requirements

--- a/ckanext/ukdstheme/assets/css/ukdstheme.css
+++ b/ckanext/ukdstheme/assets/css/ukdstheme.css
@@ -1,0 +1,14 @@
+ /* Popover */
+ .popover {
+    width: 400px;
+    max-width: 400px;
+    text-align : justify
+ }
+ .popover .popover-content
+ {
+    word-break: break-word;
+ }
+
+ .MRD_info {
+    cursor: pointer;
+ }

--- a/ckanext/ukdstheme/assets/js/ukdstheme.js
+++ b/ckanext/ukdstheme/assets/js/ukdstheme.js
@@ -1,0 +1,49 @@
+// Enable JavaScript's strict mode. Strict mode catches some common
+// programming errors and throws exceptions, prevents some unsafe actions from
+// being taken, and disables some confusing and bad JavaScript features.
+"use strict";
+
+ckan.module('ukdstheme_popover_info', function ($)
+{
+  return {
+    initialize: function ()
+    {
+      //We only go through the popover creation if "type" and "title" are available.
+      if (!!this.options.type && !!this.options.title)
+      {
+        let content;
+        let html = false;
+
+        switch (this.options.type) {
+          case "MRD_info":
+
+              //For the Machine-readable data header, we provide an html content.
+              content = `
+                <span>Machine readable data is data structured in a format that can be understood and processed by a computer.
+                Here we provide a number of file formats for machine processing:</span>
+                <br/>
+                <ul>
+                  <li>
+                    <span><b>API</b> - The CKAN native RPC-style Action API that generates JSON data in CKAN native format. For more information please visit the <a href="https://docs.ckan.org/en/latest/api/index.html" target="_blank">guide</a></span>
+                  </li>
+                  <li>
+                    <span><b>RDF</b> - The Resource Description Framework (RDF) format is a standard for description of interchanging data. It is served in different syntaxes including XML, Turtle, Notation3 and JSON-LD.</span>
+                  </li>
+                </ul>
+              `;
+              html = true;
+            break;
+          default:
+            break;
+        }
+
+
+        this.el.popover({title:this.options.title,
+          content: content,
+          html : html,
+          placement: 'right'});
+
+      }
+    }
+  };
+});

--- a/ckanext/ukdstheme/assets/webassets.yml
+++ b/ckanext/ukdstheme/assets/webassets.yml
@@ -1,14 +1,14 @@
-# customised_fields_from_tag_vocabulary-js:
-#   filter: rjsmin
-#   output: ckanext-customised_fields_from_tag_vocabulary/%(version)s-customised_fields_from_tag_vocabulary.js
-#   contents:
-#     - js/customised_fields_from_tag_vocabulary.js
-#   extra:
-#     preload:
-#       - base/main
+ukdstheme-js:
+  filter: rjsmin
+  output: ckanext-ukdstheme/%(version)s-ukdstheme.js
+  contents:
+    - js/ukdstheme.js
+  extra:
+    preload:
+      - base/main
 
-# customised_fields_from_tag_vocabulary-css:
-#   filter: cssrewrite
-#   output: ckanext-customised_fields_from_tag_vocabulary/%(version)s-customised_fields_from_tag_vocabulary.css
-#   contents:
-#     - css/customised_fields_from_tag_vocabulary.css
+ukdstheme-css:
+  filter: cssrewrite
+  output: ckanext-ukdstheme/%(version)s-ukdstheme.css
+  contents:
+    - css/ukdstheme.css

--- a/ckanext/ukdstheme/plugin.py
+++ b/ckanext/ukdstheme/plugin.py
@@ -23,6 +23,7 @@ class UKDSThemePlugin(plugins.SingletonPlugin):
         # plugin.py file.
         toolkit.add_template_directory(config, 'templates')
         toolkit.add_public_directory(config, 'public')
+        toolkit.add_resource('assets', 'ukdstheme')
 
     # ITemplateHelpers
 

--- a/ckanext/ukdstheme/templates/package/read_base.html
+++ b/ckanext/ukdstheme/templates/package/read_base.html
@@ -7,3 +7,34 @@
     {{ h.build_nav_icon(dataset_type ~ '.activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock-o') }}
   {% endif %} 
 {% endblock %}
+
+{% block secondary_content %}
+
+  {% block secondary_help_content %}{% endblock %}
+
+  {% block package_info %}
+    {% snippet 'package/snippets/info.html', pkg=pkg %}
+  {% endblock %}
+
+  {% block package_organization %}
+    {% if pkg.organization %}
+      {% set org = h.get_organization(pkg.organization.id) %}
+      {% snippet "snippets/organization.html", organization=org, has_context_title=true %}
+    {% endif %}
+  {% endblock %}
+
+  {% block package_social %}
+    {% snippet "snippets/social.html" %}
+  {% endblock %}
+
+  {% block package_license %}
+    {% snippet "snippets/license.html", pkg_dict=pkg %}
+  {% endblock %}
+
+  {% if 'dcat' in g.plugins %}
+    {% block mrd_section %}
+      {% snippet "snippets/mrd_section.html", pkg_dict=pkg %}
+    {% endblock %}
+  {% endif %}
+
+{% endblock %}

--- a/ckanext/ukdstheme/templates/snippets/mrd_section.html
+++ b/ckanext/ukdstheme/templates/snippets/mrd_section.html
@@ -1,0 +1,29 @@
+{% block DCAT %}
+    
+    {% asset "ukdstheme/ukdstheme-js" %}
+    {% asset "ukdstheme/ukdstheme-css" %}
+    
+    <section class="module module-narrow module-shallow license">
+    {% block DCAT_title %}
+        <h2 class="module-heading MRD_info"
+            data-module="ukdstheme_popover_info"
+            data-module-type="MRD_info"
+            data-module-title="Machine-readable data"
+        >
+                <i class="fa fa-info"></i> {{ _('Machine-readable data') }}
+        </h2>
+    {% endblock %}
+    {% block DCAT_nav %}
+        <ul class="nav nav-simple">
+            {% if pkg_dict.name %}
+                <li class="nav-item"><a href="{{ h.url_for_static('/api/3/action/package_show?id=') }}{{pkg_dict.name}}" target="_blank">API</a></li>
+            {% endif %}
+            <li class="nav-item"><a href="{{ h.full_current_url() }}.xml" target="_blank">RDF/XML</a></li>
+            <li class="nav-item"><a href="{{ h.full_current_url() }}.ttl" target="_blank">Turtle</a></li>
+            <li class="nav-item"><a href="{{ h.full_current_url() }}.n3" target="_blank">Notation3</a></li>
+            <li class="nav-item"><a href="{{ h.full_current_url() }}.jsonld" target="_blank">JSON-LD</a></li>
+            <li class="nav-item"><a href="https://github.com/ckan/ckanext-dcat#overview" target="_blank">DCAT documentation</a></li>
+        </ul>
+    {% endblock %}
+    </section>
+{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.0.9',
+    version='0.0.10',
 
     description='''CKAN theme plugin for the UKDS CKAN platform''',
     long_description=long_description,


### PR DESCRIPTION
Added new snippet "mrd_section.html" with the section, and assets to implement "popover" pop-up for information. Snippet is visible in the side section of the dataset page (package/read_base.html template used for this) when DCAT extension is installed and enabled.